### PR TITLE
Add support for self-signed CAs that are in the OS trust store

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"strings"
 	"text/template"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/Luzifer/go_helpers/str"
 	"github.com/Luzifer/rconfig"
-	"github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/vault/api"
 	homedir "github.com/mitchellh/go-homedir"
 )
@@ -101,13 +99,8 @@ func main() {
 	var err error
 
 	clientConfig := api.DefaultConfig()
+	clientConfig.ReadEnvironment()
 	clientConfig.Address = cfg.VaultAddress
-
-	tlsConfig := clientConfig.HttpClient.Transport.(*http.Transport).TLSClientConfig
-	err = rootcerts.ConfigureTLS(tlsConfig, nil)
-	if err != nil {
-		log.Fatalf("Could not configure TLS: %s", err)
-	}
 
 	client, err = api.NewClient(clientConfig)
 	if err != nil {


### PR DESCRIPTION
Due to a bug in the handling of CAs in the OS trust store on OSX, the current version fails when trying to access vault if signed with a self-signed CA.

```
$ vault-openvpn --auto-revoke --pki-mountpoint pki/openvpn client me.test.com
2016/08/25 15:39:16 Could not revoke certificate: Get https://vault.service.consul:8200/v1/pki/openvpn/certs?list=true: x509: certificate signed by unknown authority
```

The latest version of vault's `api.NewClient` already does the right thing when the passed config is nil, and they have added a new `Client.SetAddress(string)` method to set the address.

As I didn't want to mess with the godeps imports, I've backported the self-signed TLS handling to support only CAs that are already in the trust store, and it doesn't modify the behaviour in any other situation that was already currently working.

```
$ vault-openvpn --auto-revoke --pki-mountpoint pki/openvpn client me.test.com
2016/08/25 16:27:36 Found certificate 08:b2:d4:2e:85:d2:69:c3:5a:1d:a3:12:96:7e:7c:d7:2c:62:d7:be with CN vpn.test.com
```
