### PR TITLE
revoke all existing certificates for FQDN instead of only first one

### DIFF
--- a/main.go
+++ b/main.go
@@ -370,7 +370,10 @@ func revokeCertificateByFQDN(fqdn string) error {
 
 	for _, cert := range certs {
 		if cert.Subject.CommonName == fqdn {
-			return revokeCertificateBySerial(certutil.GetHexFormatted(cert.SerialNumber.Bytes(), ":"))
+			err := revokeCertificateBySerial(certutil.GetHexFormatted(cert.SerialNumber.Bytes(), ":"))
+	    if err != nil {
+		    return err
+	    }
 		}
 	}
 


### PR DESCRIPTION
The current code returns after revoking the first certificate it encounters. If more than one certificate exists for the FQDN they should all be revoked.