### PR TITLE
write complete ca chain as ca

### DIFF
--- a/main.go
+++ b/main.go
@@ -401,7 +401,7 @@ func revokeCertificateBySerial(serial string) error {
 }
 
 func getCACert() (string, error) {
-	path := strings.Join([]string{strings.Trim(cfg.PKIMountPoint, "/"), "cert", "ca"}, "/")
+	path := strings.Join([]string{strings.Trim(cfg.PKIMountPoint, "/"), "cert", "ca_chain"}, "/")
 	cs, err := client.Logical().Read(path)
 	if err != nil {
 		return "", errors.New("Unable to read certificate: " + err.Error())


### PR DESCRIPTION
When using an intermediate ca to sign the certificates, the <ca> section of the config should contain the complete ca chain.