### PR TITLE
Fixes error when '~/.vault-token' contains a trailing newline

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,5 +116,5 @@ func vaultTokenFromDisk() string {
 		return ""
 	}
 
-	return string(data)
+	return strings.TrimSpace(string(data))
 }


### PR DESCRIPTION
First of all, thanks again for the great tool!

This PR fixes an error encountered by one of our developers which occured when they had manually created the `~/.vault-token` file, and their editor had added a trailing newline. The error comes from the following line: https://github.com/hashicorp/vault/blob/master/api/client.go#L747

The main vault cli was patched for this in https://github.com/hashicorp/vault/commit/f8c657a80a6b8e6dc5baa06febe0b67f00ced96e, after issues https://github.com/hashicorp/vault/issues/1774 and https://github.com/hashicorp/vault/issues/1902.